### PR TITLE
initialize import/export

### DIFF
--- a/DependencyInjection/InnovaCollecticielExtension.php
+++ b/DependencyInjection/InnovaCollecticielExtension.php
@@ -15,5 +15,6 @@ class InnovaCollecticielExtension extends Extension
         $locator = new FileLocator(__DIR__ . '/../Resources/config/services');
         $loader = new YamlFileLoader($container, $locator);
         $loader->load('listeners.yml');
+        $loader->load('importers.yml');
     }
 }

--- a/Manager/CollecticielManager.php
+++ b/Manager/CollecticielManager.php
@@ -1,6 +1,7 @@
 <?php
 namespace Innova\CollecticielBundle\Manager;
 
+use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Claroline\CoreBundle\Manager\MaskManager;
 use Claroline\CoreBundle\Entity\User;
 use Innova\CollecticielBundle\Entity\Dropzone;
@@ -51,5 +52,32 @@ class CollecticielManager
         }
 
         return $adminInnova;
+    }
+
+    /**
+     * Import a Collecticiel into the platform
+     * @param array $data
+     * @param array $created
+     * @return Dropzone
+     */
+    public function import(array $data, array $created)
+    {
+        $collecticiel = new Dropzone();
+
+        return $collecticiel;
+    }
+
+    /**
+     * Export a Collecticiel
+     * @param  Workspace $workspace
+     * @param  array $files
+     * @param  Dropzone $dropzone
+     * @return array
+     */
+    public function export(Workspace $workspace, array $files, Dropzone $dropzone)
+    {
+        $data = array ();
+
+        return $data;
     }
 }

--- a/Resources/config/config.yml
+++ b/Resources/config/config.yml
@@ -7,6 +7,7 @@ plugin:
           class: Innova\CollecticielBundle\Entity\Dropzone
           is_visible: true
           is_browsable: false
+          is_exportable: true
           icon: icap_eval_icon.png
           actions:
             - name: open

--- a/Resources/config/services/importers.yml
+++ b/Resources/config/services/importers.yml
@@ -1,0 +1,8 @@
+services:
+    # Collecticiel importer
+    innova_collecticiel.importer.collecticiel:
+        class: Innova\CollecticielBundle\Transfer\CollecticielImporter
+        calls:
+            - [setContainer, ["@service_container"]]
+        tags:
+            - { name: claroline.importer }

--- a/Transfer/CollecticielImporter.php
+++ b/Transfer/CollecticielImporter.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Innova\CollecticielBundle\Transfer;
+
+use Claroline\CoreBundle\Entity\Workspace\Workspace;
+use Claroline\CoreBundle\Library\Transfert\RichTextInterface;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Processor;
+use Claroline\CoreBundle\Library\Transfert\Importer;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class CollecticielImporter extends Importer implements ConfigurationInterface
+{
+    /**
+     * We need to inject the whole service container
+     * if we try to only inject PathManager, there is a crash because of a circular reference into services
+     *
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'innova_collecticiel';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        return 99;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('data');
+
+        $rootNode
+            ->children()
+
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(array $data)
+    {
+        $processor = new Processor();
+        $processor->processConfiguration($this, $data);
+    }
+
+    public function import(array $data, $name, $created)
+    {
+        return $this->container->get('innova.manager.collecticiel_manager')->import($data, $created);
+    }
+
+    public function export(Workspace $workspace, array &$files, $object)
+    {
+        return $this->container->get('innova.manager.collecticiel_manager')->export($workspace, $files, $object);
+    }
+}


### PR DESCRIPTION
Initialize classes for import/export.

For instance the Importer does not export Collecticiel data.
We need to talk with JJQ & co. to know which information is relevant to export.

Because, it may be not interesting to export student's work as they may be not exists in the destination platform.