### PR TITLE
Update drop.html.twig

### DIFF
--- a/Resources/views/Drop/drop.html.twig
+++ b/Resources/views/Drop/drop.html.twig
@@ -142,8 +142,8 @@
 {% block javascripts %}
     {{ parent() }}
 
-    {% javascripts debug=false  output='vendor/twbs/bootstrap/js/change_me.js'
-    '../vendor/twbs/bootstrap/js/modal.js' %}
+    {% javascripts debug=false  output='vendor/twitter/bootstrap/js/change_me.js'
+    '../vendor/twitter/bootstrap/js/modal.js' %}
     <script type="text/javascript" src="{{ asset_url }}"></script>
     {% endjavascripts %}
     {% javascripts


### PR DESCRIPTION
They removed stable tags from the twbs packagist repository -_-. I'm updating the CoreBundle to use twitter/boostrap instead but paths are changing.